### PR TITLE
chore: update Button component border styles and bump version to 0.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nhc-dga-ui",
-  "version": "0.4.1",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nhc-dga-ui",
-      "version": "0.4.1",
+      "version": "0.5.5",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.24.4",

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -41,8 +41,8 @@ const Button = React.forwardRef<HTMLButtonElement, DGA_ButtonProps>(
       hoverBackgroundColor = theme.palette[colorNameResult][100];
       activeBackgroundColor = theme.palette[colorNameResult][200];
       fontColor = buttonColors[colorNameResult].default;
-      border = `border: 2px solid ${theme.palette[colorNameResult][200]}`;
-      borderFocus = "border: 2px solid transparent;";
+      border = `border: 1px solid ${theme.palette[colorNameResult][500]}`;
+      borderFocus = "border: 1px solid transparent;";
     }
     if (variantResult === "text") {
       backgroundColor = "transparent";


### PR DESCRIPTION
This pull request makes a minor update to the `Button` component, specifically adjusting the border thickness and color for buttons with the "outlined" variant. The border is now thinner and uses a different shade from the theme palette.

- UI consistency update:
  * Changed the "outlined" button border from `2px solid` with the 200 shade to `1px solid` with the 500 shade, and updated the focus border to match the new thickness. (`src/components/Button/index.tsx`)