### PR TITLE
refactor: update Grid component to use responsive column spans and im…

### DIFF
--- a/src/components/Grid/index.stories.tsx
+++ b/src/components/Grid/index.stories.tsx
@@ -20,27 +20,30 @@ export const Default: Story = {
     container: true,
     columnSpacing: 8,
     rowSpacing: 8,
+    lg: 4,
+    md: 6,
+    sm: 12,
   },
   render: function Render(args) {
     return (
       <div style={{ width: 600 }}>
         <Grid {...args}>
-          <Grid lg={4} md={6} sm={12}>
+          <Grid lg={args.lg} md={args.md} sm={args.sm}>
             Item 1
           </Grid>
-          <Grid lg={4} md={6} sm={12}>
+          <Grid lg={args.lg} md={args.md} sm={args.sm}>
             Item 2
           </Grid>
-          <Grid lg={4} md={6} sm={12}>
+          <Grid lg={args.lg} md={args.md} sm={args.sm}>
             Item 3
           </Grid>
-          <Grid lg={4} md={6} sm={12}>
+          <Grid lg={args.lg} md={args.md} sm={args.sm}>
             Item 4
           </Grid>
-          <Grid lg={4} md={6} sm={12}>
+          <Grid lg={args.lg} md={args.md} sm={args.sm}>
             Item 5
           </Grid>
-          <Grid lg={4} md={6} sm={12}>
+          <Grid lg={args.lg} md={args.md} sm={args.sm}>
             Item 6
           </Grid>
         </Grid>
@@ -49,26 +52,26 @@ export const Default: Story = {
   },
 };
 
-export const Rtl = withRtl(() => {
+export const Rtl = withRtl((args) => {
   return (
     <div style={{ width: 600 }}>
       <Grid container columnSpacing={8} rowSpacing={8}>
-        <Grid lg={4} md={6} sm={12}>
+        <Grid lg={args.lg} md={args.md} sm={args.sm}>
           Item 1
         </Grid>
-        <Grid lg={4} md={6} sm={12}>
+        <Grid lg={args.lg} md={args.md} sm={args.sm}>
           Item 2
         </Grid>
-        <Grid lg={4} md={6} sm={12}>
+        <Grid lg={args.lg} md={args.md} sm={args.sm}>
           Item 3
         </Grid>
-        <Grid lg={4} md={6} sm={12}>
+        <Grid lg={args.lg} md={args.md} sm={args.sm}>
           Item 4
         </Grid>
-        <Grid lg={4} md={6} sm={12}>
+        <Grid lg={args.lg} md={args.md} sm={args.sm}>
           Item 5
         </Grid>
-        <Grid lg={4} md={6} sm={12}>
+        <Grid lg={args.lg} md={args.md} sm={args.sm}>
           Item 6
         </Grid>
       </Grid>

--- a/src/components/Grid/index.tsx
+++ b/src/components/Grid/index.tsx
@@ -27,26 +27,26 @@ const Grid: React.FC<DGA_GridProps> = ({
   const theme = useTheme();
   const { isMobile, isTablet, isDesktop } = useScreenSizes();
 
-  const getColumnWidthPercentage = () => {
-    let result = 100;
+  const getColumnSpan = () => {
+    let result = 12; // Default to full width
     if (isMobile && sm) {
-      result = (sm * 100) / 12;
+      result = sm;
     }
     if (isTablet) {
       if (md) {
-        result = (md * 100) / 12;
+        result = md;
       } else if (sm) {
-        result = (sm * 100) / 12;
+        result = sm;
       }
     }
 
     if (isDesktop) {
       if (lg) {
-        result = (lg * 100) / 12;
+        result = lg;
       } else if (md) {
-        result = (md * 100) / 12;
+        result = md;
       } else if (sm) {
-        result = (sm * 100) / 12;
+        result = sm;
       }
     }
     return result;
@@ -76,7 +76,7 @@ const Grid: React.FC<DGA_GridProps> = ({
     <StyledComponentItem
       {...props}
       $theme={theme}
-      $columnWidthPercentage={+getColumnWidthPercentage().toFixed(3)}
+      $columnSpan={getColumnSpan()}
       $columnSpacing={columnSpacing}
       className={mergeStrings("dgaui dgaui_gridItem", props.className)}
     >
@@ -91,23 +91,18 @@ const StyledComponentContainer = styled.div<{
   $rowSpacing: number;
 }>`
   direction: ${(p) => p.$theme.direction};
-  display: flex;
-  flex-wrap: wrap;
-
-  column-gap: ${(p) => p.$columnSpacing}px;
-  row-gap: ${(p) => p.$rowSpacing}px;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: ${(p) => p.$rowSpacing}px ${(p) => p.$columnSpacing}px;
 `;
 
 const StyledComponentItem = styled.div<{
   $theme: Theme;
-  $columnWidthPercentage: number;
+  $columnSpan: number;
   $columnSpacing: number;
 }>`
   direction: ${(p) => p.$theme.direction};
-  flex: ${(p) =>
-    p.$columnSpacing > 0
-      ? `0 1 calc(${p.$columnWidthPercentage}% - ${p.$columnSpacing}px)`
-      : `${p.$columnWidthPercentage}%`};
+  grid-column: span ${(p) => p.$columnSpan};
 `;
 
 export default Grid;


### PR DESCRIPTION
This pull request refactors the `Grid` component to use CSS Grid instead of flexbox, simplifies how column spans are calculated, and updates the storybook stories to make column sizing more dynamic and consistent with the new implementation.

**Grid layout refactor:**

* Refactored `Grid` to use CSS Grid (`display: grid`) with `grid-template-columns: repeat(12, 1fr)` instead of flexbox, enabling more precise and flexible column layouts. (`src/components/Grid/index.tsx`)
* Updated grid item styling to use `grid-column: span` based on a new `$columnSpan` prop, replacing the previous flex-based width calculation. (`src/components/Grid/index.tsx`)

**Column span calculation:**

* Simplified the logic for determining column span by directly using the `lg`, `md`, and `sm` props, instead of calculating width percentages. (`src/components/Grid/index.tsx`) [[1]](diffhunk://#diff-2e20c9e3f4d76684899cf356878e12a5ad3ab78ee3a06ad707c1b4f7c8a57413L30-R49) [[2]](diffhunk://#diff-2e20c9e3f4d76684899cf356878e12a5ad3ab78ee3a06ad707c1b4f7c8a57413L79-R79)

**Storybook improvements:**

* Updated the `Default` and `Rtl` stories to pass `lg`, `md`, and `sm` props dynamically from `args`, ensuring the stories accurately reflect the new grid behavior and are easier to customize. (`src/components/Grid/index.stories.tsx`) [[1]](diffhunk://#diff-3715f85a84acb715dc55742dbdec04f7ea8d8084594fe400596eae95cdc2352eR23-R46) [[2]](diffhunk://#diff-3715f85a84acb715dc55742dbdec04f7ea8d8084594fe400596eae95cdc2352eL52-R74)…prove layout handling in stories